### PR TITLE
Display acceleration vector

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -47,6 +47,7 @@ P2_C     = (110, 210, 120)
 PING_C   = ( 60, 230, 110)
 ECHO_C   = (240, 120,  60)
 IMPACT_C = (255,  90,  90)
+ACCEL_VEC_C = (255, 210,   0)
 TXT_C    = (  0,   0,   0)
 
 TAU = math.tau          # 2π, útil para cálculos angulares


### PR DESCRIPTION
## Summary
- visualize each bot's acceleration as a capped arrow
- annotate HUD with acceleration magnitude

## Testing
- `python -m py_compile constants.py game.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893867604dc832596f28a1141ed69e2