### PR TITLE
Add angular velocity tracking and HUD

### DIFF
--- a/game.py
+++ b/game.py
@@ -31,10 +31,12 @@ class SumoSensorsGame:
         """Reinicia la partida creando bots nuevos y limpiando estados."""
         self.player = B.PlayerBot((C.CENTER[0]-120, C.CENTER[1]), C.PLAYER_C)
         self.player.heading_deg = 0
+        self.player.prev_heading = 0
         self.opponent = (B.Player2Bot if self.two_players else B.CpuBot)(
             (C.CENTER[0]+120, C.CENTER[1]),
             C.P2_C if self.two_players else C.CPU_C)
         self.opponent.heading_deg = 180
+        self.opponent.prev_heading = 180
         self.game_over = False
         self.winner    = ""
         self.replay_mode = False
@@ -112,6 +114,10 @@ class SumoSensorsGame:
             f"ay = {ay:6.2f} m/s²",
             f"|a| = {amag:6.2f} m/s²",
             f"|a| = {amag/C.G_MSS:5.2f} g",
+            "",
+            "Velocidad angular:",
+            "ω = Δθ/Δt",
+            f"ω = {bot.ang_vel:6.2f} °/s",
         ]
 
         for i, line in enumerate(lines):

--- a/recorder.py
+++ b/recorder.py
@@ -19,6 +19,7 @@ class Recorder:
             "p2x": p2.pos.x, "p2y": p2.pos.y, "p2h": p2.heading_deg,
             "p1ax": p1.accel[0], "p1ay": p1.accel[1],
             "p2ax": p2.accel[0], "p2ay": p2.accel[1],
+            "p1w": p1.ang_vel, "p2w": p2.ang_vel,
         })
         if len(self.frames) > self.max_frames:
             self.frames.pop(0)


### PR DESCRIPTION
## Summary
- track angular velocity for all bots and record it each frame
- log angular velocity in recorder for potential CSV export
- show ω = Δθ/Δt on the HUD along with current angular velocity

## Testing
- `python -m py_compile bots.py game.py recorder.py`


------
https://chatgpt.com/codex/tasks/task_e_68938676f9f08325ba230061cb98d7a8