### PR TITLE
Add line sensor edge distance

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -54,6 +54,7 @@ class Bot:
         """Crea un bot en ``pos`` y con color ``colour``."""
         self.pos         = Vector2(pos)
         self.heading_deg = 0.0
+        self.base_colour = colour
         self.colour      = colour
         self.vel         = Vector2()
         self.prev_vel    = Vector2()
@@ -63,6 +64,7 @@ class Bot:
 
         self.accel       = (0.0, 0.0)
         self.accel_time  = 0
+        self.alert       = False
 
     # ― física ―
     def integrate(self, dt_ms):
@@ -94,6 +96,12 @@ class Bot:
         self.accel = (ax, ay)
         self.accel_time = pygame.time.get_ticks()
         self.prev_vel = self.vel
+
+    # ― sensor de línea ―
+    def edge_distance(self):
+        """Distancia en píxeles desde el bot hasta el borde del dojo."""
+        pos = (self.pos.x, self.pos.y)
+        return C.DOJO_RADIUS - U.dist_to_center(pos)
 
     # ― sonar ―
     def _compute_ping_hit(self, opponent):

--- a/game.py
+++ b/game.py
@@ -98,8 +98,13 @@ class SumoSensorsGame:
         tof_ms  = (2 * dist_cm) / C.V_SOUND_CMMS
         ax, ay  = bot.accel
         amag    = math.hypot(ax, ay)
+        edge_d  = bot.edge_distance()
 
         lines = [
+            "Sensor de línea:",
+            "d = R - r",
+            f"d = {edge_d:6.1f} px",
+            "",
             "Ultrasonido:",
             "d = (v · t) / 2",
             f"v = {C.V_SOUND_CMMS/100:.0f} m/s",
@@ -207,6 +212,11 @@ class SumoSensorsGame:
                     self.opponent.launch_ping(now, self.player)
                     self.player.update_ping(dt)
                     self.opponent.update_ping(dt)
+
+                    # sensor de línea
+                    for b in (self.player, self.opponent):
+                        b.alert = b.edge_distance() < C.BOT_RADIUS*2
+                        b.colour = C.IMPACT_C if b.alert else b.base_colour
 
                     # KO
                     if not U.within_ring_with_radius(self.player.pos):


### PR DESCRIPTION
## Summary
- add `edge_distance` method to bots and track alert state/colour
- show line sensor info and formula on HUD
- trigger alert colour when nearing dojo edge

## Testing
- `python -m py_compile bots.py game.py utils.py constants.py recorder.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68938679800083259f7e7d937475a797