### PR TITLE
Add infrared sensor simulation and HUD formulas

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -66,6 +66,11 @@ class Bot:
         self.ang_vel     = 0.0
         self.prev_heading= 0.0
 
+        self.ir_intensity = 0.0
+        self.ir_rho       = C.IR_RHO_BLACK
+        self.ir_dist_cm   = 0.0
+        self.ir_colour    = "negro"
+
     # ― física ―
     def integrate(self, dt_ms):
         """Integra la velocidad actual para actualizar la posición."""
@@ -107,6 +112,22 @@ class Bot:
         dtheta = (self.heading_deg - self.prev_heading + 540) % 360 - 180
         self.ang_vel = dtheta / (dt_ms/1000.0)
         self.prev_heading = self.heading_deg
+
+    # ― sensor infrarrojo ―
+    def update_ir(self):
+        """Actualiza la lectura del sensor IR según la posición actual."""
+        dist_px = U.dist_to_center((self.pos.x, self.pos.y))
+        self.ir_dist_cm = dist_px / C.PX_PER_CM
+        if U.on_white_line((self.pos.x, self.pos.y)):
+            self.ir_rho = C.IR_RHO_WHITE
+            self.ir_colour = "blanco"
+        else:
+            self.ir_rho = C.IR_RHO_BLACK
+            self.ir_colour = "negro"
+        if dist_px > 0:
+            self.ir_intensity = (C.IR_POWER * self.ir_rho) / (dist_px ** 2)
+        else:
+            self.ir_intensity = 0.0
 
     # ― sonar ―
     def _compute_ping_hit(self, opponent, noisy=True):

--- a/constants.py
+++ b/constants.py
@@ -38,6 +38,11 @@ PING_NOISE_RANGE = (0, 40)
 ACCEL_DISPLAY_MS = 600
 G_MSS = 9.81
 
+# ── Sensor infrarrojo ────────────────────────────────────────────
+IR_POWER     = 1000.0             # potencia emitida (unidad arb.)
+IR_RHO_WHITE = 0.9                # reflectividad (blanco)
+IR_RHO_BLACK = 0.2                # reflectividad (negro)
+
 # ── Colores (RGB) ───────────────────────────────────────────────
 GREY_BG   = (225, 225, 225)
 RING_FILL = ( 20,  20,  20)

--- a/game.py
+++ b/game.py
@@ -42,6 +42,8 @@ class SumoSensorsGame:
         self.replay_mode = False
         self.replay_idx  = 0
         self.rec.frames.clear()
+        self.player.update_ir()
+        self.opponent.update_ir()
 
     def toggle_two_players(self):
         """Activa o desactiva el modo de dos jugadores."""
@@ -144,6 +146,13 @@ class SumoSensorsGame:
             "Velocidad angular:",
             "ω = Δθ/Δt",
             f"ω = {bot.ang_vel:6.2f} °/s",
+            "",
+            "Sensor IR:",
+            "I = P · ρ / d²",
+            f"d = {bot.ir_dist_cm:6.1f} cm",
+            f"ρ = {bot.ir_rho:4.2f}",
+            f"I = {bot.ir_intensity:6.2f}",
+            f"color = {bot.ir_colour}",
         ]
 
         for i, line in enumerate(lines):
@@ -238,16 +247,18 @@ class SumoSensorsGame:
                         self.opponent.update(keys, dt)
                     self.player.push_apart(self.opponent)
 
-                    # sonar
+                    # sensores
+                    self.player.update_ir()
+                    self.opponent.update_ir()
                     self.player.launch_ping(now, self.opponent)
                     self.opponent.launch_ping(now, self.player)
                     self.player.update_ping(dt)
                     self.opponent.update_ping(dt)
 
-                    # KO
-                    if not U.within_ring_with_radius(self.player.pos):
+                    # KO por línea blanca
+                    if U.on_white_line(self.player.pos) or not U.within_ring_with_radius(self.player.pos):
                         self.winner = "CPU" if not self.two_players else "JUGADOR 2"
-                    if not U.within_ring_with_radius(self.opponent.pos):
+                    if U.on_white_line(self.opponent.pos) or not U.within_ring_with_radius(self.opponent.pos):
                         self.winner = "JUGADOR" if not self.two_players else "JUGADOR 1"
                     if self.winner:
                         self.game_over=True

--- a/utils.py
+++ b/utils.py
@@ -21,6 +21,11 @@ def within_ring_with_radius(pos):
     """¿El centro del bot (con radio) sigue dentro del dojo?"""
     return dist_to_center(pos) <= (C.DOJO_RADIUS - C.BOT_RADIUS)
 
+def on_white_line(pos):
+    """¿El sensor infrarrojo detecta la línea blanca del borde?"""
+    d = dist_to_center(pos)
+    return (C.DOJO_RADIUS - C.RING_EDGE) <= d <= (C.DOJO_RADIUS + C.RING_EDGE)
+
 # ── Amortiguación dependiente de dt ────────────────────────────
 def damping_factor(dt_ms: float):
     """Factor de amortiguación para un intervalo ``dt_ms``."""


### PR DESCRIPTION
## Summary
- simulate IR floor sensor using reflectivity and inverse-square law
- show IR physics formulas and readings in HUD
- detect white perimeter line to decide KOs in circular dojo

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68955da874d083258560a57da446fe00