### PR TITLE
Fix dojo ring visuals and HUD contrast

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -12,6 +12,7 @@ SCREEN_W, SCREEN_H = 900, 700
 CENTER = (SCREEN_W // 2, SCREEN_H // 2)
 DOJO_RADIUS = int(40 * PX_PER_CM)        # 80 cm de diámetro → 40 cm de radio
 RING_EDGE   = int(5 * PX_PER_CM)         # grosor borde blanco (5 cm)
+OUTER_RING_WIDTH = int(7 * PX_PER_CM)    # grosor del área negra exterior (7 cm)
 CENTER_MARK_RADIUS = int(5 * PX_PER_CM)  # radio del círculo azul central (5 cm)
 BOT_RADIUS  = 18                 # px
 
@@ -43,8 +44,6 @@ G_MSS = 9.81
 
 
 GREY_BG   = (225, 225, 225)
-RING_FILL = ( 20,  20,  20)
-RING_EDGE_C = (255, 255, 255)
 
 # ── Sensor infrarrojo ────────────────────────────────────────────
 IR_POWER     = 1000.0             # potencia emitida (unidad arb.)
@@ -55,8 +54,8 @@ IR_SENSOR_HEIGHT_CM = 2.0         # altura fija del sensor sobre el suelo
 
 
 # ── Colores (RGB) ───────────────────────────────────────────────
-BG_C         = (  0,   0,   0)
-RING_FILL    = BG_C
+BG_C         = GREY_BG
+RING_FILL    = (  0,   0,   0)
 RING_EDGE_C  = (255, 255, 255)
 CENTER_MARK_C= (  0,   0, 255)
 

--- a/game.py
+++ b/game.py
@@ -47,9 +47,10 @@ class SumoSensorsGame:
         self.replay_idx = 0
 
     def _ring(self):
-        pygame.draw.circle(self.scr, C.RING_FILL, C.CENTER, C.DOJO_RADIUS)
-        pygame.draw.circle(self.scr, C.CENTER_MARK_C, C.CENTER, C.CENTER_MARK_RADIUS)
+        outer_radius = C.DOJO_RADIUS + C.RING_EDGE + C.OUTER_RING_WIDTH
+        pygame.draw.circle(self.scr, C.RING_FILL, C.CENTER, outer_radius)
         pygame.draw.circle(self.scr, C.RING_EDGE_C, C.CENTER, C.DOJO_RADIUS, C.RING_EDGE)
+        pygame.draw.circle(self.scr, C.CENTER_MARK_C, C.CENTER, C.CENTER_MARK_RADIUS)
 
     def _draw_bot(self, bot):
         pygame.draw.circle(self.scr, bot.colour, (int(bot.pos.x), int(bot.pos.y)), C.BOT_RADIUS)


### PR DESCRIPTION
## Summary
- Replace grey gap and outer white ring with a solid black surround around the dojo
- Simplify ring geometry constants and render dojo fill as pure black

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68956e892c988325984200fe0dbb5666