### PR TITLE
fix: stop CPU bot spinning after target detection

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -247,6 +247,7 @@ class CpuBot(Bot):
                     self.state = "pursue"
                     self.heading_deg = ang_to
                     self.scan_rot = 0
+                    self.record_ang_vel(0)
                     self.record_accel(dt_ms)
                     return
 


### PR DESCRIPTION
## Summary
- reset angular velocity when switching from scan to pursue so the CPU bot stops spinning and moves toward its opponent

## Testing
- `python -m py_compile bots.py constants.py game.py gyroscope.py main.py recorder.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6895770d8ca4832592834c2b197b2563