### PR TITLE
fix: slow CPU scan and halt spin after detection

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -228,15 +228,7 @@ class CpuBot(Bot):
         now_ms = pygame.time.get_ticks()
 
         if self.state == "scan":
-            # gira sobre su eje lanzando pings y sin desplazarse
-            turn = C.CPU_TURN * (dt_ms / 16.6667)
-            self.heading_deg = (self.heading_deg + turn) % 360
-
-            self.record_ang_vel(dt_ms)
-            self.vel.xy = (0.0, 0.0)
-            self.launch_ping(now_ms, target_bot)
-            self.update_ping(dt_ms)
-            # detección básica dentro del campo de visión del sonar
+            # detección básica dentro del campo de visión del sonar antes de girar
             dx = target_bot.pos.x - self.pos.x
             dy = target_bot.pos.y - self.pos.y
             dist = math.hypot(dx, dy)
@@ -247,8 +239,19 @@ class CpuBot(Bot):
                     self.state = "pursue"
                     self.heading_deg = ang_to
                     self.scan_rot = 0
+                    self.vel.xy = (0.0, 0.0)
+                    self.record_ang_vel(0)
                     self.record_accel(dt_ms)
                     return
+
+            # gira sobre su eje lanzando pings y sin desplazarse
+            turn = C.CPU_TURN * (dt_ms / 16.6667)
+            self.heading_deg = (self.heading_deg + turn) % 360
+
+            self.record_ang_vel(dt_ms)
+            self.vel.xy = (0.0, 0.0)
+            self.launch_ping(now_ms, target_bot)
+            self.update_ping(dt_ms)
 
             self.scan_rot += abs(turn)
             self.record_accel(dt_ms)

--- a/constants.py
+++ b/constants.py
@@ -25,7 +25,7 @@ WAVE_SPEED_PX_MS = (V_SOUND_CMMS / 100) * PX_PER_CM   # ≃ 1.37 px ms-1
 # ── Movimiento ──────────────────────────────────────────────────
 TURN_DEG            = 4          # giro jugador (° frame-1)
 MOVE_ACC            = 950.0       # aceleración jugador (px s-2)
-CPU_TURN            = 4          # giro máximo CPU (° frame-1)
+CPU_TURN            = 1.0        # giro máximo CPU (° frame-1)
 
 MAX_SPEED           = 260.0
 CPU_SPEED           = 150.0


### PR DESCRIPTION
## Summary
- switch to pursuit before rotating to stop the CPU bot spinning once it spots the opponent
- lower CPU scan speed so the sweep is more realistic and less agile

## Testing
- `python -m py_compile bots.py constants.py game.py gyroscope.py main.py recorder.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6895770d8ca4832592834c2b197b2563