### PR TITLE
Improve CPU bot roaming and KO logic

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -259,19 +259,28 @@ class CpuBot(Bot):
                 self.state = "move"
                 self.move_time = 0
                 self.scan_rot = 0
-                self.heading_deg = random.uniform(0, 360)
+                # elige un desplazamiento discreto (adelante, atrás, izquierda o derecha)
+                self.heading_deg = (self.heading_deg +
+                                     random.choice((0, 90, 180, -90))) % 360
 
 
         elif self.state == "move":
-            # avanza recto durante un breve periodo antes de volver a escanear
+            # avanza unos pasos y se detiene; si detecta el borde, retrocede
+            self.update_ir()
+            if self.ir_colour == "blanco":
+                # el sensor ha encontrado el borde: gira 180° y reinicia paso
+                self.heading_deg = (self.heading_deg + 180) % 360
+                self.move_time = 0
+
             vx, vy = U.unit_vec(self.heading_deg)
             self.vel = Vector2(vx*C.CPU_SPEED, vy*C.CPU_SPEED)
             if self.vel.length() > C.MAX_SPEED:
                 self.vel.scale_to_length(C.MAX_SPEED)
             self.apply_damping(dt_ms); self.integrate(dt_ms)
             self.record_accel(dt_ms); self.record_ang_vel(dt_ms)
+
             self.move_time += dt_ms
-            if self.move_time >= 1000:
+            if self.move_time >= 500:
                 self.state = "scan"
                 self.vel.xy = (0.0, 0.0)
 

--- a/game.py
+++ b/game.py
@@ -238,10 +238,10 @@ class SumoSensorsGame:
                     self.player.update_ping(dt)
                     self.opponent.update_ping(dt)
 
-                    # KO por línea blanca
-                    if U.on_white_line(self.player.pos) or not U.within_ring_with_radius(self.player.pos):
+                    # KO cuando un bot abandona el dojo
+                    if not U.within_ring_with_radius(self.player.pos):
                         self.winner = "CPU" if not self.two_players else "JUGADOR 2"
-                    if U.on_white_line(self.opponent.pos) or not U.within_ring_with_radius(self.opponent.pos):
+                    if not U.within_ring_with_radius(self.opponent.pos):
                         self.winner = "JUGADOR" if not self.two_players else "JUGADOR 1"
                     if self.winner:
                         self.game_over=True


### PR DESCRIPTION
## Summary
- Let CPU bot move in discrete steps and reverse when IR detects the edge
- Only trigger KOs when a bot fully leaves the dojo

## Testing
- `pytest`
- `python -m py_compile bots.py game.py`


------
https://chatgpt.com/codex/tasks/task_e_68957a78e9748325af6534a98b2d3d27