### PR TITLE
Reset CPU bot angular velocity on move

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -262,6 +262,7 @@ class CpuBot(Bot):
                 # elige un desplazamiento discreto (adelante, atrás, izquierda o derecha)
                 self.heading_deg = (self.heading_deg +
                                      random.choice((0, 90, 180, -90))) % 360
+                self.record_ang_vel(0)
 
 
         elif self.state == "move":


### PR DESCRIPTION
## Summary
- prevent CPU bot from spinning after scan by zeroing angular velocity when switching to move state

## Testing
- `python -m py_compile bots.py`


------
https://chatgpt.com/codex/tasks/task_e_68958300c7908325b804aded0e8f6d66