### PR TITLE
Require contact for KO and improve edge recovery

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -277,8 +277,8 @@ class CpuBot(Bot):
             prev_pos = self.pos.copy()
             self.integrate(dt_ms)
             self.update_ir()
-            if self.ir_colour == "blanco":
-                # el sensor ha encontrado el borde: retrocede y reinicia paso
+            if self.ir_colour == "blanco" or not U.within_ring_with_radius(self.pos):
+                # el sensor ha encontrado el borde o se salió del dojo: retrocede y reinicia paso
                 self.pos = prev_pos
                 self.heading_deg = (self.heading_deg + 180) % 360
                 self.record_ang_vel(0)
@@ -303,8 +303,8 @@ class CpuBot(Bot):
             prev_pos = self.pos.copy()
             self.integrate(dt_ms)
             self.update_ir()
-            if self.ir_colour == "blanco":
-                # si detecta el borde, retrocede y vuelve a escanear
+            if self.ir_colour == "blanco" or not U.within_ring_with_radius(self.pos):
+                # si detecta el borde o se salió del dojo, retrocede y vuelve a escanear
                 self.pos = prev_pos
                 self.heading_deg = (self.heading_deg + 180) % 360
                 self.record_ang_vel(0)

--- a/game.py
+++ b/game.py
@@ -242,6 +242,7 @@ class SumoSensorsGame:
                         self.opponent.update(self.player, dt)
                     else:
                         self.opponent.update(keys, dt)
+                    bots_touching = self.player.pos.distance_to(self.opponent.pos) <= C.BOT_RADIUS * 2
                     self.player.push_apart(self.opponent)
                     # sensores
                     self.player.update_ir()
@@ -251,15 +252,15 @@ class SumoSensorsGame:
                     self.player.update_ping(dt)
                     self.opponent.update_ping(dt)
 
-                    # KO cuando un bot abandona el dojo
-                    if not U.within_ring_with_radius(self.player.pos):
+                    # KO cuando un bot abandona el dojo mientras es empujado
+                    if not U.within_ring_with_radius(self.player.pos) and bots_touching:
                         if self.mode == "player_cpu":
                             self.winner = "CPU"
                         elif self.mode == "two_players":
                             self.winner = "JUGADOR 2"
                         else:
                             self.winner = "CPU 2"
-                    if not U.within_ring_with_radius(self.opponent.pos):
+                    if not U.within_ring_with_radius(self.opponent.pos) and bots_touching:
                         if self.mode == "player_cpu":
                             self.winner = "JUGADOR"
                         elif self.mode == "two_players":


### PR DESCRIPTION
## Summary
- avoid KO unless a bot touches opponent while outside ring
- CPU bots reverse or reset when leaving ring even if sensor misses white line

## Testing
- `python -m py_compile bots.py game.py`


------
https://chatgpt.com/codex/tasks/task_e_68965fc595448325b239425f9ea8584e